### PR TITLE
🐞 Fix macOS install issues and improve reliability

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,9 +1,14 @@
 import type { Command } from 'commander'
 import type { GitHubSource } from '@/core/downloader'
 import type { FileEntry, ResolvedLocation } from '@/core/resolver'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, normalize, resolve } from 'node:path'
-import { getConfigPath, getProjectRoot, readConfig } from '@/core/config'
+import {
+  getConfigPath,
+  getProjectRoot,
+  knownProviders,
+  readConfig,
+} from '@/core/config'
 import { downloadFile } from '@/core/downloader'
 import { installSkillset, pruneUnchanged } from '@/core/installer'
 import {
@@ -11,7 +16,7 @@ import {
   resolveIdentifier,
   resolveSkillset,
 } from '@/core/resolver'
-import { dim, green, reset } from '@/utils/ansi'
+import { cyan, dim, green, reset } from '@/utils/ansi'
 import { createStepper } from '@/utils/stepper'
 
 const toGitHubSource = (entry: FileEntry, ref: string): GitHubSource => ({
@@ -88,11 +93,18 @@ const renderTree = (node: TreeNode, prefix = ''): string[] =>
     return [`${prefix}${connector} ${name}`, ...renderTree(child, childPrefix)]
   })
 
-const printSummary = (files: string[]) => {
+const stripProviderPrefix = (file: string, prefix: string): string => {
+  const norm = prefix.replace(/\\/g, '/').replace(/^\.\//, '')
+  return file.startsWith(`${norm}/`) ? file.slice(norm.length + 1) : file
+}
+
+const printSummary = (files: string[], providerPath: string) => {
   if (files.length === 0) return
-  const unique = [...new Set(files)]
+  const unique = [...new Set(files)].map((f) =>
+    stripProviderPrefix(f, providerPath),
+  )
   const tree = buildFileTree(unique)
-  process.stdout.write(`\n📂 Installed files:\n`)
+  process.stdout.write(`\n📂${providerPath}\n`)
   renderTree(tree).forEach((line) => {
     process.stdout.write(`  ${dim}${line}${reset}\n`)
   })
@@ -108,7 +120,7 @@ const registerInstallCommand = (program: Command) => {
       const startedAt = Date.now()
 
       try {
-        const { config } = readConfig()
+        readConfig()
 
         stepper.start('Resolving endpoint...', 'packages')
         const location = await resolveIdentifier(input)
@@ -122,17 +134,15 @@ const registerInstallCommand = (program: Command) => {
           `${skillset.name} v${skillset.version}`,
         )
 
-        const providerEntry = Object.entries(config.providers).find(
-          ([name]) => name === skillset.provider,
-        )
+        const providerPath = knownProviders[skillset.provider]
 
-        if (!providerEntry) {
+        if (!providerPath) {
           throw new Error(
-            `Provider "${skillset.provider}" not found in config. Run "spm init" to detect providers.`,
+            `Unknown provider "${skillset.provider}". Known providers: ${Object.keys(knownProviders).join(', ')}`,
           )
         }
 
-        const [, provider] = providerEntry
+        const provider = { path: providerPath }
 
         const entries = resolveSkillset(skillset, location)
         if (entries.length === 0) {
@@ -183,18 +193,23 @@ const registerInstallCommand = (program: Command) => {
           stepper.succeed(`Skipped ${pruned} unchanged file(s)`)
         }
 
+        const model = skillset.provider === 'claude' ? 'haiku' : undefined
+
         const result = await installSkillset(
           {
             downloadDir,
             setupFile,
-            providerDir: provider.path,
+            providerDir: providerFullPath,
             skillsetName: skillset.name,
             skillsetVersion: skillset.version,
             source: `@${location.owner}/${location.repository}`,
             configPath: getConfigPath(),
+            model,
           },
           stepper,
         )
+
+        await rm(downloadDir, { recursive: true, force: true })
 
         stepper.stop()
 
@@ -209,7 +224,11 @@ const registerInstallCommand = (program: Command) => {
 
         const summaryFiles =
           result.files.length > 0 ? result.files : downloadedPaths
-        printSummary(summaryFiles)
+        printSummary(summaryFiles, provider.path)
+
+        process.stdout.write(
+          `\n🪄  ${cyan}Restart your AI agent to apply the new skills.${reset}\n`,
+        )
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         stepper.fail(message)

--- a/src/core/installer/install-skill.ts
+++ b/src/core/installer/install-skill.ts
@@ -7,6 +7,11 @@ const installSkillset = (
   input: InstallInput,
   stepper: Stepper,
 ): Promise<InstallResult> =>
-  spawnClaude(writeInstructionsFile(input), stepper, input.providerDir)
+  spawnClaude(
+    writeInstructionsFile(input),
+    stepper,
+    input.providerDir,
+    input.model,
+  )
 
 export { installSkillset }

--- a/src/core/installer/install.md
+++ b/src/core/installer/install.md
@@ -32,8 +32,7 @@ Step headers (use these exactly):
 4. `Integrating...`
 5. `Updating config...`
 6. `Running setup...` (only if a setup file exists)
-7. `Cleaning up...`
-8. `Done`
+7. `Done`
 
 Example output:
 
@@ -59,14 +58,11 @@ Updating config...
 Running setup...
   • Configured MCP server: biome
 
-Cleaning up...
-  • Removed .spm/skill-creator
-
 Done
 
 ## Step 1: Analyzing existing setup
 
-Read the provider directory (`{{providerDir}}`) and catalog what is already in place: skills, rules, agents, hooks, mcp servers, memory files.
+Read the provider directory (`{{providerDir}}`) and catalog what is already in place: skills, rules, agents, hooks, mcp servers files.
 
 ## Step 2: Analyzing downloaded files
 
@@ -107,12 +103,8 @@ Update `{{configPath}}`:
 
 {{setupSection}}
 
-## Step 7: Cleaning up (last step before Done)
-
-Delete the download folder `{{downloadDir}}` and its contents.
-
 ## Rules
 
 - Setup files are NOT installed — they contain instructions to configure the project
 - Do not delete or modify existing files in the provider directory unless resolving a conflict
-- Always delete the download folder when done
+- Do NOT delete the download folder — cleanup is handled externally

--- a/src/core/installer/spawn-claude.ts
+++ b/src/core/installer/spawn-claude.ts
@@ -2,8 +2,6 @@ import type { FunCategory, Stepper } from '@/utils/stepper'
 import type { InstallResult } from './types'
 import { spawn } from 'node:child_process'
 
-const TIMEOUT_MS = 120_000
-
 type ContentBlock = {
   type: string
   text?: string
@@ -63,6 +61,7 @@ const spawnClaude = (
   instructionsFilePath: string,
   stepper: Stepper,
   providerDir: string,
+  model?: string,
 ): Promise<InstallResult> =>
   new Promise((resolve, reject) => {
     const args = [
@@ -75,12 +74,12 @@ const spawnClaude = (
       'stream-json',
       '--allowedTools',
       'Read,Write,Edit,Bash,Glob,Grep',
+      ...(model ? ['--model', model] : []),
     ]
 
     const isWindows = process.platform === 'win32'
 
     const child = spawn('claude', args, {
-      timeout: TIMEOUT_MS,
       shell: isWindows,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
@@ -90,7 +89,7 @@ const spawnClaude = (
     let currentStepHeader = 'Analyzing existing setup...'
     let stepItems: string[] = []
     let stepFileCount = 0
-    const state = { doneReceived: false }
+    const state = { doneReceived: false, setupReached: false }
     const writtenFiles: string[] = []
 
     const succeedCurrentStep = () => {
@@ -114,10 +113,12 @@ const spawnClaude = (
       }
 
       if (currentStepHeader.startsWith('Running setup')) {
-        const context = stepItems.length === 1 ? stepItems[0] : undefined
-        stepper.succeed('Skillset setup completed', context)
+        stepper.succeed('Skillset setup completed')
+        currentStepHeader = ''
         return
       }
+
+      if (state.setupReached || currentStepHeader.startsWith('Cleaning')) return
 
       const context = stepItems.length === 1 ? stepItems[0] : undefined
       stepper.succeed(base, context)
@@ -160,9 +161,14 @@ const spawnClaude = (
                 if (isStepHeader(ln, trimmed)) {
                   if (trimmed === currentStepHeader) return
                   succeedCurrentStep()
+                  if (state.setupReached || trimmed.startsWith('Cleaning'))
+                    return
                   currentStepHeader = trimmed
                   stepItems = []
                   stepFileCount = 0
+                  if (trimmed.startsWith('Running setup')) {
+                    state.setupReached = true
+                  }
                   stepper.start(trimmed, stepCategory(trimmed))
                 } else if (!currentStepHeader.startsWith('Integrating')) {
                   stepItems.push(trimmed)
@@ -195,7 +201,10 @@ const spawnClaude = (
       })
     })
 
-    child.stderr.on('data', () => {})
+    let stderrBuffer = ''
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrBuffer += chunk.toString()
+    })
 
     child.on('error', (err) => {
       if ('code' in err && err.code === 'ENOENT') {
@@ -216,13 +225,19 @@ const spawnClaude = (
 
       const completed = state.doneReceived || resultText.length > 0
 
+      const stderr = stderrBuffer.trim()
+
       if (code !== 0 && code !== null) {
-        reject(new Error(`Claude CLI exited with code ${code}`))
+        const detail = stderr ? `\n${stderr}` : ''
+        reject(new Error(`Claude CLI exited with code ${code}${detail}`))
         return
       }
 
-      if (code === null && !completed) {
-        reject(new Error('Claude CLI was interrupted before completing'))
+      if (code === null) {
+        const detail = stderr ? `\n${stderr}` : ''
+        reject(
+          new Error(`Claude CLI was interrupted before completing${detail}`),
+        )
         return
       }
 

--- a/src/core/installer/types.ts
+++ b/src/core/installer/types.ts
@@ -6,6 +6,7 @@ type InstallInput = {
   skillsetVersion: string
   source: string
   configPath: string
+  model?: string
 }
 
 type InstallResult = {

--- a/tests/core/installer/install-skill.test.ts
+++ b/tests/core/installer/install-skill.test.ts
@@ -57,6 +57,7 @@ describe('installSkillset', () => {
       '/tmp/spm/install-dev-tools.md',
       stepper,
       '.claude',
+      undefined,
     )
   })
 

--- a/tests/core/installer/spawn-claude.test.ts
+++ b/tests/core/installer/spawn-claude.test.ts
@@ -63,7 +63,7 @@ describe('spawnClaude', () => {
     await expect(promise).rejects.toThrow('Claude CLI not found')
   })
 
-  it('rejects on non-zero exit code when Done was not received', async () => {
+  it('rejects on non-zero exit code', async () => {
     const child = createMockChild()
     const stepper = createMockStepper()
     mockSpawn.mockReturnValue(child as never)
@@ -72,6 +72,18 @@ describe('spawnClaude', () => {
     child.emit('close', 1)
 
     await expect(promise).rejects.toThrow('exited with code 1')
+  })
+
+  it('includes stderr in error message on non-zero exit', async () => {
+    const child = createMockChild()
+    const stepper = createMockStepper()
+    mockSpawn.mockReturnValue(child as never)
+
+    const promise = spawnClaude('/tmp/instructions.md', stepper, '.claude')
+    child.stderr.emit('data', Buffer.from('something went wrong'))
+    child.emit('close', 1)
+
+    await expect(promise).rejects.toThrow('something went wrong')
   })
 
   it('passes correct arguments to spawn', async () => {
@@ -96,7 +108,7 @@ describe('spawnClaude', () => {
         '--allowedTools',
         'Read,Write,Edit,Bash,Glob,Grep',
       ],
-      expect.objectContaining({ timeout: 120_000 }),
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
     )
   })
 


### PR DESCRIPTION
Closes #21

## Summary

- Fix files installing to global `.claude` by using absolute provider paths
- Remove 120s spawn timeout that caused SIGTERM (exit code 143) on slow installs
- Expose stderr in error messages for debugging
- Resolve provider from static map instead of requiring directory detection
- Clean up `.spm` download folder after installation
- Suppress duplicate/noisy stepper output from setup step
- Use haiku model for Claude provider installs
- Show restart message and provider-rooted file tree after install

## Test plan

- [x] All 76 tests pass
- [ ] Test `spm install` on macOS in empty folder
- [ ] Test `spm install` on macOS in existing project
- [ ] Verify `.spm` folder is removed after install
- [ ] Verify files install to project `.claude`, not global